### PR TITLE
feat: add watch daemon for automatic index rebuilds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::path::Path;
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Config {
     #[serde(default)]
     pub db_path: Option<String>,
@@ -12,12 +12,32 @@ pub struct Config {
     pub packages: Vec<PackageOverride>,
     #[serde(default)]
     pub symbols: SymbolsConfig,
+    #[serde(default)]
+    pub watch: WatchConfig,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct SymbolsConfig {
     #[serde(default)]
     pub exclude_extensions: Vec<String>,
+}
+
+fn default_debounce_ms() -> u64 {
+    2000
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct WatchConfig {
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
+}
+
+impl Default for WatchConfig {
+    fn default() -> Self {
+        Self {
+            debounce_ms: default_debounce_ms(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -36,7 +56,7 @@ pub struct CustomDiscoveryRule {
     pub extensions: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct DiscoveryConfig {
     #[serde(default = "default_manifests")]
     pub manifests: Vec<String>,
@@ -87,7 +107,7 @@ fn default_exclude() -> Vec<String> {
     ]
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct PackageOverride {
     pub name: String,
     pub description: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod db;
 mod index;
 mod mcp;
 mod symbols;
+mod watch;
 
 #[derive(Parser)]
 #[command(name = "shire", about = "Monorepo package index and MCP server")]
@@ -35,6 +36,33 @@ enum Commands {
         #[arg(long)]
         db: Option<PathBuf>,
     },
+    /// Start the watch daemon for automatic index rebuilds
+    Watch {
+        /// Root directory of the repository (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        /// Stop the running daemon
+        #[arg(long)]
+        stop: bool,
+        /// Run in foreground (used internally by the daemon)
+        #[arg(long, hide = true)]
+        foreground: bool,
+        /// Path to the index database (overrides shire.toml db_path)
+        #[arg(long)]
+        db: Option<PathBuf>,
+    },
+    /// Signal the watch daemon to rebuild the index
+    Rebuild {
+        /// Root directory of the repository (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        /// Specific file that changed (can be repeated)
+        #[arg(long)]
+        file: Vec<PathBuf>,
+        /// Read Claude Code hook JSON from stdin to extract the changed file
+        #[arg(long)]
+        stdin: bool,
+    },
 }
 
 #[tokio::main]
@@ -55,6 +83,47 @@ async fn main() -> Result<()> {
                 );
             }
             mcp::run_server(&db_path).await
+        }
+        Commands::Watch {
+            root,
+            stop,
+            foreground,
+            db,
+        } => {
+            let root = std::fs::canonicalize(&root)?;
+            if stop {
+                watch::daemon::stop_daemon(&root)
+            } else if foreground {
+                let config = config::load_config(&root)?;
+                watch::run_daemon(root, config, db).await
+            } else {
+                watch::daemon::start_daemon(&root, db.as_deref())
+            }
+        }
+        Commands::Rebuild {
+            root,
+            mut file,
+            stdin,
+        } => {
+            let root = if stdin {
+                match watch::protocol::HookInput::from_stdin() {
+                    Some(hook) if !hook.should_rebuild() => return Ok(()),
+                    Some(hook) => {
+                        if let Some(path) = hook.tool_input.file_path {
+                            file.push(path);
+                        } else if let Some(path) = hook.tool_input.notebook_path {
+                            file.push(path);
+                        }
+                        // Use cwd from hook JSON as root (falls back to --root)
+                        hook.cwd.unwrap_or(root)
+                    }
+                    None => root,
+                }
+            } else {
+                root
+            };
+            let root = std::fs::canonicalize(&root)?;
+            watch::send_rebuild(&root, file)
         }
     }
 }

--- a/src/watch/daemon.rs
+++ b/src/watch/daemon.rs
@@ -1,0 +1,104 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn pid_path(root: &Path) -> PathBuf {
+    root.join(".shire/watch.pid")
+}
+
+pub fn sock_path(root: &Path) -> PathBuf {
+    root.join(".shire/watch.sock")
+}
+
+fn log_path(root: &Path) -> PathBuf {
+    root.join(".shire/watch.log")
+}
+
+/// Check if the daemon is running by reading the PID file and sending signal 0.
+pub fn is_running(root: &Path) -> bool {
+    let pid_file = pid_path(root);
+    let Ok(contents) = std::fs::read_to_string(&pid_file) else {
+        return false;
+    };
+    let Ok(pid) = contents.trim().parse::<u32>() else {
+        return false;
+    };
+    // kill -0 checks process existence without sending a signal
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Start the daemon by re-exec'ing this binary with `watch --foreground`.
+/// Idempotent: returns Ok(()) if already running.
+pub fn start_daemon(root: &Path, db: Option<&Path>) -> Result<()> {
+    if is_running(root) {
+        return Ok(());
+    }
+
+    // Clean up stale state files
+    let _ = std::fs::remove_file(pid_path(root));
+    let _ = std::fs::remove_file(sock_path(root));
+
+    let exe = std::env::current_exe().context("failed to resolve current executable")?;
+    let log_file = std::fs::File::create(log_path(root))
+        .context("failed to create watch.log")?;
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("watch")
+        .arg("--root")
+        .arg(root)
+        .arg("--foreground");
+
+    if let Some(db_path) = db {
+        cmd.arg("--db").arg(db_path);
+    }
+
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(log_file);
+
+    let child = cmd.spawn().context("failed to spawn watch daemon")?;
+
+    // Write PID file
+    std::fs::write(pid_path(root), child.id().to_string())
+        .context("failed to write PID file")?;
+
+    Ok(())
+}
+
+/// Stop the daemon by sending SIGTERM and cleaning up state files.
+/// Idempotent: returns Ok(()) if not running.
+pub fn stop_daemon(root: &Path) -> Result<()> {
+    let pid_file = pid_path(root);
+    let contents = match std::fs::read_to_string(&pid_file) {
+        Ok(c) => c,
+        Err(_) => return Ok(()), // No PID file, nothing to stop
+    };
+    let pid = match contents.trim().parse::<u32>() {
+        Ok(p) => p,
+        Err(_) => {
+            // Invalid PID file, clean up
+            let _ = std::fs::remove_file(&pid_file);
+            let _ = std::fs::remove_file(sock_path(root));
+            return Ok(());
+        }
+    };
+
+    // Send SIGTERM
+    let _ = Command::new("kill")
+        .args([&pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    // Clean up state files
+    let _ = std::fs::remove_file(&pid_file);
+    let _ = std::fs::remove_file(sock_path(root));
+
+    Ok(())
+}

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -1,0 +1,217 @@
+pub mod daemon;
+pub mod protocol;
+
+use crate::config::Config;
+use crate::index;
+use crate::symbols::walker;
+use anyhow::{Context, Result};
+use protocol::RebuildMessage;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::UnixListener;
+use tokio::sync::mpsc;
+
+/// Check whether a file is relevant to the index.
+/// Must be inside the repo root AND be a manifest, source, or config file.
+fn is_relevant(
+    path: &Path,
+    root: &Path,
+    manifest_names: &HashSet<&str>,
+    source_exts: &HashSet<&str>,
+) -> bool {
+    // Must be inside the repo root
+    if !path.starts_with(root) {
+        return false;
+    }
+
+    let filename = match path.file_name().and_then(|f| f.to_str()) {
+        Some(f) => f,
+        None => return false,
+    };
+
+    // shire config change
+    if filename == "shire.toml" {
+        return true;
+    }
+
+    // Manifest file (package.json, go.mod, Cargo.toml, etc.)
+    if manifest_names.contains(filename) {
+        return true;
+    }
+
+    // Source file with a tracked extension
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        if source_exts.contains(ext) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Send a rebuild signal to the daemon via UDS.
+/// Graceful no-op if the daemon is not running or the socket doesn't exist.
+pub fn send_rebuild(root: &Path, files: Vec<PathBuf>) -> Result<()> {
+    let sock = daemon::sock_path(root);
+    if !sock.exists() {
+        return Ok(());
+    }
+
+    let msg = RebuildMessage { files };
+    let mut payload = serde_json::to_string(&msg).context("failed to serialize rebuild message")?;
+    payload.push('\n');
+
+    // Use std::os::unix::net for a blocking connect + write (fire-and-forget)
+    match std::os::unix::net::UnixStream::connect(&sock) {
+        Ok(mut stream) => {
+            use std::io::Write;
+            let _ = stream.write_all(payload.as_bytes());
+            Ok(())
+        }
+        Err(_) => Ok(()), // Daemon not listening, no-op
+    }
+}
+
+/// Run the daemon event loop (called with --foreground).
+/// Binds UDS, accepts rebuild signals, debounces, and runs build_index.
+pub async fn run_daemon(
+    root: PathBuf,
+    config: Config,
+    db_override: Option<PathBuf>,
+) -> Result<()> {
+    let sock = daemon::sock_path(&root);
+
+    // Remove stale socket file before binding
+    let _ = std::fs::remove_file(&sock);
+
+    let listener = UnixListener::bind(&sock)
+        .context("failed to bind Unix socket")?;
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<RebuildMessage>();
+
+    eprintln!("[watch] daemon started, listening on {}", sock.display());
+
+    // Spawn connection acceptor task
+    let tx_clone = tx.clone();
+    let accept_handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let tx = tx_clone.clone();
+                    tokio::spawn(async move {
+                        let reader = BufReader::new(stream);
+                        let mut lines = reader.lines();
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            match serde_json::from_str::<RebuildMessage>(&line) {
+                                Ok(msg) => {
+                                    let _ = tx.send(msg);
+                                }
+                                Err(e) => {
+                                    eprintln!("[watch] invalid message: {e}");
+                                }
+                            }
+                        }
+                    });
+                }
+                Err(e) => {
+                    eprintln!("[watch] accept error: {e}");
+                }
+            }
+        }
+    });
+
+    // Debounce loop
+    let debounce = std::time::Duration::from_millis(config.watch.debounce_ms);
+
+    // Build relevance filter sets
+    let manifest_names: HashSet<&str> = config
+        .discovery
+        .manifests
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    let source_exts: HashSet<&str> = walker::all_extensions().into_iter().collect();
+
+    // Set up signal handler for graceful shutdown
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+
+    loop {
+        // Wait for first signal or shutdown
+        tokio::select! {
+            Some(first_msg) = rx.recv() => {
+                // Accumulate files across the debounce window
+                let mut all_files: Vec<PathBuf> = first_msg.files;
+
+                // Got a rebuild signal, start debounce window
+                let deadline = tokio::time::Instant::now() + debounce;
+
+                // Drain any additional signals during debounce window
+                loop {
+                    tokio::select! {
+                        Some(msg) = rx.recv() => {
+                            all_files.extend(msg.files);
+                        }
+                        _ = tokio::time::sleep_until(deadline) => {
+                            break;
+                        }
+                    }
+                }
+
+                // If files were specified, check relevance before rebuilding.
+                // Empty file list = unconditional rebuild (manual `shire rebuild`).
+                if !all_files.is_empty() {
+                    let dominated_by_irrelevant = all_files
+                        .iter()
+                        .all(|f| !is_relevant(f, &root, &manifest_names, &source_exts));
+                    if dominated_by_irrelevant {
+                        let names: Vec<_> = all_files
+                            .iter()
+                            .filter_map(|f| f.file_name().and_then(|n| n.to_str()))
+                            .collect();
+                        eprintln!("[watch] skipping rebuild — no relevant files: {}", names.join(", "));
+                        continue;
+                    }
+                }
+
+                // Run build
+                let build_root = root.clone();
+                let build_config = config.clone();
+                let build_db = db_override.clone();
+
+                eprintln!("[watch] triggering rebuild...");
+                let result = tokio::task::spawn_blocking(move || {
+                    index::build_index(
+                        &build_root,
+                        &build_config,
+                        false,
+                        build_db.as_deref(),
+                    )
+                })
+                .await;
+
+                match result {
+                    Ok(Ok(())) => eprintln!("[watch] rebuild completed"),
+                    Ok(Err(e)) => eprintln!("[watch] rebuild failed: {e}"),
+                    Err(e) => eprintln!("[watch] rebuild task panicked: {e}"),
+                }
+            }
+            _ = sigterm.recv() => {
+                eprintln!("[watch] received SIGTERM, shutting down");
+                break;
+            }
+            _ = sigint.recv() => {
+                eprintln!("[watch] received SIGINT, shutting down");
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    accept_handle.abort();
+    let _ = std::fs::remove_file(&sock);
+    let _ = std::fs::remove_file(daemon::pid_path(&root));
+    eprintln!("[watch] daemon stopped");
+    Ok(())
+}

--- a/src/watch/protocol.rs
+++ b/src/watch/protocol.rs
@@ -1,0 +1,164 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Message sent over UDS to signal a rebuild.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RebuildMessage {
+    #[serde(default)]
+    pub files: Vec<PathBuf>,
+}
+
+/// Claude Code hook JSON received on stdin for PostToolUse events.
+#[derive(Debug, Deserialize)]
+pub struct HookInput {
+    pub tool_name: Option<String>,
+    pub tool_input: ToolInput,
+    /// Working directory of the Claude Code session (repo root).
+    pub cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ToolInput {
+    pub file_path: Option<PathBuf>,
+    /// NotebookEdit uses notebook_path instead of file_path
+    pub notebook_path: Option<PathBuf>,
+    /// Bash tool command string
+    pub command: Option<String>,
+}
+
+/// Bash commands known to be read-only. If every segment of a piped/chained
+/// command starts with one of these, we skip the rebuild.
+const READONLY_COMMANDS: &[&str] = &[
+    "cat", "head", "tail", "less", "more",
+    "ls", "dir", "find", "fd", "tree",
+    "grep", "rg", "ag", "ack",
+    "wc", "diff", "cmp", "file", "stat",
+    "echo", "printf", "true", "false",
+    "pwd", "which", "whereis", "whence", "type", "command",
+    "env", "printenv", "set",
+    "ps", "top", "htop", "uptime", "df", "du", "free",
+    "date", "cal",
+    "man", "help", "info",
+    "git status", "git log", "git diff", "git show", "git branch",
+    "git remote", "git tag", "git stash list", "git rev-parse",
+    "cargo test", "cargo check", "cargo clippy", "cargo bench", "cargo doc",
+    "cargo build",
+    "go test", "go vet", "go build",
+    "npm test", "npm run test", "npm run lint", "npm run build",
+    "npx", "yarn test", "pnpm test",
+    "python -c", "python -m pytest", "pytest", "node -e",
+    "make check", "make test",
+    "jq", "yq", "xargs",
+    "curl", "wget", "http",
+    "docker ps", "docker images", "docker logs",
+    "kubectl get", "kubectl describe", "kubectl logs",
+    "gh pr view", "gh issue view", "gh api", "gh run view",
+];
+
+impl HookInput {
+    /// Parse Claude Code hook JSON from stdin.
+    /// Returns None if parsing fails (non-fatal — caller falls back to empty file list).
+    pub fn from_stdin() -> Option<Self> {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).ok()?;
+        serde_json::from_str(&buf).ok()
+    }
+
+    /// Whether this hook event should trigger a rebuild signal.
+    /// For Bash: returns false only for commands known to be read-only.
+    /// Unknown commands default to triggering a rebuild (safe default).
+    pub fn should_rebuild(&self) -> bool {
+        if self.tool_name.as_deref() != Some("Bash") {
+            return true;
+        }
+
+        let cmd = match self.tool_input.command.as_deref() {
+            Some(c) => c,
+            None => return true,
+        };
+
+        // Check every segment of piped/chained commands.
+        // If ALL are read-only, skip. If ANY is unknown, rebuild.
+        !cmd.split(&['|', ';'][..])
+            .map(|s| s.trim().trim_start_matches('('))
+            // split on && (crude: split on & then skip empty segments)
+            .flat_map(|s| s.split("&&").map(|s| s.trim()))
+            .filter(|s| !s.is_empty())
+            .all(|segment| {
+                READONLY_COMMANDS.iter().any(|ro| segment.starts_with(ro))
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hook(tool_name: &str, command: Option<&str>) -> HookInput {
+        HookInput {
+            tool_name: Some(tool_name.into()),
+            tool_input: ToolInput {
+                file_path: None,
+                notebook_path: None,
+                command: command.map(|s| s.into()),
+            },
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn test_edit_always_rebuilds() {
+        assert!(hook("Edit", None).should_rebuild());
+        assert!(hook("Write", None).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_readonly_skips() {
+        assert!(!hook("Bash", Some("ls -la")).should_rebuild());
+        assert!(!hook("Bash", Some("cat foo.txt")).should_rebuild());
+        assert!(!hook("Bash", Some("git status")).should_rebuild());
+        assert!(!hook("Bash", Some("git log --oneline")).should_rebuild());
+        assert!(!hook("Bash", Some("grep -r TODO src/")).should_rebuild());
+        assert!(!hook("Bash", Some("cargo test")).should_rebuild());
+        assert!(!hook("Bash", Some("npm test")).should_rebuild());
+        assert!(!hook("Bash", Some("echo hello")).should_rebuild());
+        assert!(!hook("Bash", Some("cargo build")).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_known_mutating_rebuilds() {
+        assert!(hook("Bash", Some("mv foo bar")).should_rebuild());
+        assert!(hook("Bash", Some("cp -r src dest")).should_rebuild());
+        assert!(hook("Bash", Some("rm -rf node_modules")).should_rebuild());
+        assert!(hook("Bash", Some("sed -i 's/foo/bar/' file.txt")).should_rebuild());
+        assert!(hook("Bash", Some("npm install lodash")).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_unknown_commands_rebuild() {
+        // Unknown commands default to rebuild (safe)
+        assert!(hook("Bash", Some("protoc --go_out=. foo.proto")).should_rebuild());
+        assert!(hook("Bash", Some("buf generate")).should_rebuild());
+        assert!(hook("Bash", Some("sqlc generate")).should_rebuild());
+        assert!(hook("Bash", Some("make")).should_rebuild());
+        assert!(hook("Bash", Some("./scripts/codegen.sh")).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_piped_readonly_skips() {
+        assert!(!hook("Bash", Some("cat foo | grep bar")).should_rebuild());
+        assert!(!hook("Bash", Some("git log | head -5")).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_piped_with_unknown_rebuilds() {
+        assert!(hook("Bash", Some("cat foo | ./process.sh")).should_rebuild());
+        assert!(hook("Bash", Some("echo hi && mv a b")).should_rebuild());
+    }
+
+    #[test]
+    fn test_bash_no_command_rebuilds() {
+        assert!(hook("Bash", None).should_rebuild());
+    }
+}


### PR DESCRIPTION
## Summary

- Signal-based background daemon (`shire watch` / `shire rebuild` / `shire watch --stop`) that auto-rebuilds the index when files change during a Claude Code session
- Unix domain socket IPC with configurable debounce (default 2s) via tokio
- Smart filtering: extracts `file_path` from Edit/Write hooks for relevance checks (repo boundary + extension); denylist of read-only Bash commands (`ls`, `git status`, `cargo test`, etc.) — unknown commands default to rebuild
- `--stdin` flag reads Claude Code hook JSON directly, using `cwd` as repo root

## Hook configuration

```json
{
  "hooks": {
    "PostToolUse": [
      {
        "matcher": "Edit|Write|NotebookEdit|Bash",
        "hooks": [{ "type": "command", "command": "shire rebuild --stdin" }]
      }
    ]
  }
}
```

## New files

| File | Purpose |
|------|---------|
| `src/watch/mod.rs` | Daemon event loop (UDS listener, debounce, spawn_blocking build), `send_rebuild()` |
| `src/watch/daemon.rs` | Process management (start/stop/is_running via PID + kill) |
| `src/watch/protocol.rs` | `RebuildMessage`, `HookInput` parsing, Bash read-only denylist |

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 242 tests pass (including 7 new protocol tests)
- [x] `shire watch` → daemon starts, PID + socket created
- [x] `shire watch` again → idempotent no-op
- [x] `shire rebuild` → signal sent, build triggers after debounce
- [x] `shire rebuild --stdin` with Edit hook JSON → extracts file_path, smart filtering works
- [x] `.rs` file outside repo root → skipped (repo boundary check)
- [x] `README.md` edit → skipped (irrelevant extension)
- [x] `shire watch --stop` → daemon stops, cleanup
- [x] `shire watch --stop` again → idempotent no-op
- [x] `shire rebuild` when no daemon → graceful no-op

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)