### PR TITLE
chore: bump version to v0.1.5-beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "shire"
-version = "0.1.4-beta"
+version = "0.1.5-beta"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shire"
-version = "0.1.4-beta"
+version = "0.1.5-beta"
 edition = "2024"
 description = "One index to rule them all — Search, Hierarchy, Index, Repo Explorer, a monorepo MCP-first indexer"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps version from `0.1.4-beta` to `0.1.5-beta` in Cargo.toml

## Changes since v0.1.4-beta
- feat: add mdBook docs site with GitHub Pages deployment
- feat: add MCP prompts for semantic codebase exploration (#7)
- feat: add watch daemon for automatic index rebuilds (#6)
- feat: add custom package discovery via `[[discovery.custom]]` config
- feat: add Java, Kotlin, Perl, Ruby, and Protobuf language support

## Post-merge
Tag `v0.1.5-beta` on main after merge to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)