### PR TITLE
feat: prompt local vs global scope in shire init

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -179,6 +179,19 @@ pub fn generate_config_toml(opts: &InitOptions, global: bool) -> String {
 }
 
 pub fn run_init(root: &Path, no_hook: bool, yes: bool) -> Result<()> {
+    // In interactive mode, ask local vs global first
+    if !yes && std::io::stdin().is_terminal() {
+        let items = &["Local (this project only)", "Global (all projects)"];
+        let selection = Select::new()
+            .with_prompt("Install scope")
+            .items(items)
+            .default(0)
+            .interact()?;
+        if selection == 1 {
+            return run_init_global(no_hook, false);
+        }
+    }
+
     let opts = if yes || !std::io::stdin().is_terminal() {
         let mut defaults = InitOptions::default_local();
         if no_hook {


### PR DESCRIPTION
## Summary
- When running `shire init` interactively, adds a first prompt asking "Local (this project only)" vs "Global (all projects)"
- Selecting global routes into the existing `run_init_global` flow (MCP in `~/.claude.json`, config in `~/.claude/shire.toml`)
- `--global` flag still works for non-interactive/scripted use
- `shire init -y` continues to default to local without prompting

## Test plan
- [x] All init tests pass
- [ ] Manual: run `shire init` interactively, verify scope prompt appears first
- [ ] Manual: select Global, verify it writes to `~/.claude.json` and `~/.claude/shire.toml`
- [ ] Manual: `shire init -y` skips the prompt and defaults to local
- [ ] Manual: `shire init --global` bypasses the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)