### PR TITLE
feat: add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/result
 .shire/
 docs/book/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Shire — One index to rule them all. Monorepo MCP-first indexer.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+
+        # Include Cargo source + tree-sitter query files (.scm)
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            (builtins.match ".*\\.scm$" path != null) || (craneLib.filterCargoSources path type);
+        };
+
+        commonArgs = {
+          inherit src;
+          strictDeps = true;
+
+          buildInputs = with pkgs; [
+            openssl
+          ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.apple-sdk_15
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            git  # needed by integration tests (git init in temp dirs)
+          ];
+        };
+
+        # Build deps separately for caching
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+          cargoExtraArgs = "--no-default-features";
+        });
+
+        shire = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+
+          # Build without the rag feature (fastembed/ONNX) by default — it
+          # pulls heavy C++ deps that are difficult to build in the Nix sandbox.
+          cargoExtraArgs = "--no-default-features";
+
+          meta = {
+            description = "One index to rule them all — monorepo MCP-first indexer";
+            homepage = "https://github.com/justinjdev/shire";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "shire";
+          };
+        });
+      in
+      {
+        checks = {
+          inherit shire;
+        };
+
+        packages = {
+          default = shire;
+          shire = shire;
+        };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = shire;
+        };
+
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+
+          packages = with pkgs; [
+            rust-analyzer
+            cargo-watch
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a Nix flake using crane for reproducible builds
- Builds without the `rag` feature (fastembed/ONNX pulls heavy C++ sandbox deps)
- Includes dev shell with rust-analyzer and cargo-watch
- Adds `/result` to `.gitignore`

## Install

```sh
# Install
nix profile install github:justinjdev/shire

# Run ephemerally
nix run github:justinjdev/shire -- build

# Dev shell
nix develop
```

## Test plan
- [x] `nix flake check --no-build` passes
- [x] `nix build` succeeds (all 30 tests pass)
- [x] Built binary runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version control configuration to exclude build-generated artifacts and output directories from tracking, maintaining cleaner repository history and reducing noise in version control.
  * Introduced development environment setup configuration providing integrated build system infrastructure, compiler tooling, and development utilities for standardized workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->