### PR TITLE
test: fill cross-reference index coverage gaps

### DIFF
--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -2298,6 +2298,33 @@ mod refs_tests {
     }
 
     #[test]
+    fn test_delete_references_for_file_unknown_path_is_noop() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("t_unknown.db");
+        let conn = open_or_create(&db_path, false).unwrap();
+        let mut file_ids = seed_files(&conn, &["known.rs"]);
+
+        let refs = vec![ReferenceInfo {
+            name: "foo".into(),
+            kind: ReferenceKind::Call,
+            file_path: Arc::from("known.rs"),
+            line: 10,
+            enclosing_symbol: Some("main".into()),
+        }];
+        batch_insert_references(&conn, Some("pkg"), &refs, &mut file_ids).unwrap();
+
+        delete_references_for_file(&conn, "missing.rs").unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM symbol_refs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "deleting refs for an unknown path should be a no-op"
+        );
+    }
+
+    #[test]
     fn test_delete_references_for_package() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("t2.db");
@@ -2397,6 +2424,88 @@ mod refs_tests {
     }
 
     #[test]
+    fn test_query_symbol_references_returns_rows_without_symbol_definition() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("r_unknown_symbol.db");
+        let conn = open_or_create(&db_path, false).unwrap();
+        let ids = seed_files(&conn, &["ext.rs"]);
+        let ext = ids["ext.rs"];
+
+        // No row in `symbols` for "ExternalThing" on purpose. `symbol_references`
+        // is name-based over symbol_refs and should still return this row.
+        conn.execute(
+            &format!(
+                "INSERT INTO symbol_refs (name, kind, file_id, line, package, enclosing_symbol) \
+                 VALUES ('ExternalThing', 'call', {ext}, 7, 'pkg-ext', 'main')"
+            ),
+            [],
+        )
+        .unwrap();
+
+        let rows =
+            query_symbol_references(&conn, "ExternalThing", Some("call"), Some("pkg-ext"), 10)
+                .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "ExternalThing");
+        assert_eq!(rows[0].kind, "call");
+        assert_eq!(rows[0].file_path, "ext.rs");
+        assert_eq!(rows[0].line, 7);
+        assert_eq!(rows[0].package.as_deref(), Some("pkg-ext"));
+        assert_eq!(rows[0].enclosing_symbol.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn test_query_symbol_references_unicode_round_trip_nfc_and_nfd() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("r_unicode.db");
+        let conn = open_or_create(&db_path, false).unwrap();
+        let ids = seed_files(&conn, &["unicode.rs"]);
+        let file_id = ids["unicode.rs"];
+
+        let nfc = "Café";
+        let nfd = "Cafe\u{301}";
+        assert_ne!(
+            nfc, nfd,
+            "test requires distinct byte sequences for NFC/NFD forms"
+        );
+
+        conn.execute(
+            &format!(
+                "INSERT INTO symbol_refs (name, kind, file_id, line, package, enclosing_symbol) \
+                 VALUES ('Config', 'type', {file_id}, 10, 'pkg-u', NULL), \
+                        (?1,      'type', {file_id}, 11, 'pkg-u', NULL), \
+                        (?2,      'type', {file_id}, 12, 'pkg-u', NULL), \
+                        ('Ω',     'type', {file_id}, 13, 'pkg-u', NULL)"
+            ),
+            (nfc, nfd),
+        )
+        .unwrap();
+
+        let config =
+            query_symbol_references(&conn, "Config", Some("type"), Some("pkg-u"), 10).unwrap();
+        assert_eq!(config.len(), 1);
+        assert_eq!(config[0].name, "Config");
+        assert_eq!(config[0].line, 10);
+
+        let nfc_rows =
+            query_symbol_references(&conn, nfc, Some("type"), Some("pkg-u"), 10).unwrap();
+        assert_eq!(nfc_rows.len(), 1);
+        assert_eq!(nfc_rows[0].name, nfc);
+        assert_eq!(nfc_rows[0].line, 11);
+
+        let nfd_rows =
+            query_symbol_references(&conn, nfd, Some("type"), Some("pkg-u"), 10).unwrap();
+        assert_eq!(nfd_rows.len(), 1);
+        assert_eq!(nfd_rows[0].name, nfd);
+        assert_eq!(nfd_rows[0].line, 12);
+
+        let omega = query_symbol_references(&conn, "Ω", Some("type"), Some("pkg-u"), 10).unwrap();
+        assert_eq!(omega.len(), 1);
+        assert_eq!(omega[0].name, "Ω");
+        assert_eq!(omega[0].line, 13);
+    }
+
+    #[test]
     fn test_query_symbol_callers_groups_and_counts() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("c.db");
@@ -2413,7 +2522,9 @@ mod refs_tests {
                         ('foo', 'call', {a}, 11, 'p', 'bar'), \
                         ('foo', 'call', {b}, 5, 'p', 'quux'), \
                         ('foo', 'type', {a}, 20, 'p', 'bar'), \
-                        ('foo', 'call', {c}, 1, 'p', NULL)"
+                        ('foo', 'call', {c}, 1, 'p', NULL), \
+                        ('foo', 'call', {c}, 2, 'p', NULL), \
+                        ('foo', 'call', {c}, 3, 'p', NULL)"
             ),
             [],
         )
@@ -2430,6 +2541,15 @@ mod refs_tests {
         assert_eq!(p_only.len(), 2);
         let none = query_symbol_callers(&conn, "foo", Some("other"), 100).unwrap();
         assert!(none.is_empty());
+
+        // Proves `r.enclosing_symbol IS NOT NULL` stays in the SQL.
+        // If the filter were removed, the NULL group has the highest call-site
+        // count (3) and would sort first; with `LIMIT 1` that top row would be
+        // deserialization-dropped and we'd lose the real caller row.
+        let top = query_symbol_callers(&conn, "foo", None, 1).unwrap();
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].caller_name, "bar");
+        assert_eq!(top[0].call_sites, 2);
     }
 
     #[test]

--- a/src/symbols/hooks/mod.rs
+++ b/src/symbols/hooks/mod.rs
@@ -126,12 +126,24 @@ pub fn find_ancestor<'a>(node: &Node<'a>, kind: &str) -> Option<Node<'a>> {
 /// (or its first `identifier`/`type_identifier` child) as the enclosing symbol
 /// name. Returns None if no qualifying named ancestor is found.
 pub fn resolve_enclosing_symbol(node: &Node, source: &str, ancestors: &[&str]) -> Option<String> {
+    fn is_anonymous_callable_kind(kind: &str) -> bool {
+        matches!(
+            kind,
+            "arrow_function" | "function_expression" | "lambda" | "lambda_expression"
+        )
+    }
+
     let mut current = node.parent();
     while let Some(n) = current {
         if ancestors.contains(&n.kind()) {
             // Try the `name` field first (most grammars)
             if let Some(name) = field_text(&n, "name", source) {
                 return Some(name.to_string());
+            }
+            // Anonymous callable scopes should still be attributable, but they
+            // don't have a stable identifier node to read as a name.
+            if is_anonymous_callable_kind(n.kind()) {
+                return Some("<anonymous>".to_string());
             }
             // Fall back to scanning direct children for an identifier-like node
             for i in 0..n.child_count() {

--- a/src/symbols/query_extract.rs
+++ b/src/symbols/query_extract.rs
@@ -183,6 +183,8 @@ pub fn extract(
             std::collections::HashSet::new();
         let mut call_ranges: std::collections::HashSet<(usize, usize)> =
             std::collections::HashSet::new();
+        let mut call_name_lines: std::collections::HashSet<(String, usize)> =
+            std::collections::HashSet::new();
         let mut refs_capped = false;
         let source_bytes = source.as_bytes();
 
@@ -262,6 +264,7 @@ pub fn extract(
                     impl_ranges.insert(node_range);
                 } else if kind == ReferenceKind::Call {
                     call_ranges.insert(node_range);
+                    call_name_lines.insert((trimmed_name.clone(), line));
                 }
                 if max_references_per_file > 0
                     && pending_references.len() >= max_references_per_file
@@ -295,6 +298,7 @@ pub fn extract(
             &def_name_ranges,
             &impl_ranges,
             &call_ranges,
+            &call_name_lines,
         );
         (symbols, references)
     })
@@ -303,12 +307,15 @@ pub fn extract(
 /// Post-pass filter for buffered references. Suppresses:
 /// (a) self-references at a definition's own name node,
 /// (b) Type refs that duplicate an Impl ref at the same byte range,
-/// (c) Type refs that duplicate a Call ref at the same byte range.
+/// (c) Type refs that duplicate a Call ref at the same byte range,
+/// (d) Type refs that duplicate a Call ref by name+line (covers grammars
+///     where call captures are attached to wrapper nodes, not name nodes).
 fn filter_references(
     pending: Vec<(ReferenceInfo, (usize, usize))>,
     def_name_ranges: &std::collections::HashSet<(usize, usize)>,
     impl_ranges: &std::collections::HashSet<(usize, usize)>,
     call_ranges: &std::collections::HashSet<(usize, usize)>,
+    call_name_lines: &std::collections::HashSet<(String, usize)>,
 ) -> Vec<ReferenceInfo> {
     pending
         .into_iter()
@@ -317,7 +324,9 @@ fn filter_references(
                 return None;
             }
             if reference.kind == ReferenceKind::Type
-                && (impl_ranges.contains(&node_range) || call_ranges.contains(&node_range))
+                && (impl_ranges.contains(&node_range)
+                    || call_ranges.contains(&node_range)
+                    || call_name_lines.contains(&(reference.name.clone(), reference.line)))
             {
                 return None;
             }

--- a/src/symbols/query_extract.rs
+++ b/src/symbols/query_extract.rs
@@ -260,28 +260,28 @@ pub fn extract(
                 let enclosing =
                     resolve_enclosing_symbol(&node, source, ref_hooks.enclosing_ancestors);
                 let node_range = (node.start_byte(), node.end_byte());
+                if max_references_per_file > 0
+                    && pending_references.len() >= max_references_per_file
+                {
+                    refs_capped = true;
+                    continue;
+                }
                 if kind == ReferenceKind::Impl {
                     impl_ranges.insert(node_range);
                 } else if kind == ReferenceKind::Call {
                     call_ranges.insert(node_range);
                     call_name_lines.insert((trimmed_name.clone(), line));
                 }
-                if max_references_per_file > 0
-                    && pending_references.len() >= max_references_per_file
-                {
-                    refs_capped = true;
-                } else {
-                    pending_references.push((
-                        ReferenceInfo {
-                            name: trimmed_name,
-                            kind,
-                            file_path: file_path.clone(),
-                            line,
-                            enclosing_symbol: enclosing,
-                        },
-                        node_range,
-                    ));
-                }
+                pending_references.push((
+                    ReferenceInfo {
+                        name: trimmed_name,
+                        kind,
+                        file_path: file_path.clone(),
+                        line,
+                        enclosing_symbol: enclosing,
+                    },
+                    node_range,
+                ));
             }
         }
 
@@ -347,4 +347,43 @@ fn default_signature(name: &str, kind: SymbolKind) -> String {
         SymbolKind::Constant => "const",
     };
     format!("{} {}", keyword, name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::{Language, Parser, Query};
+
+    #[test]
+    fn test_cap_does_not_let_dropped_call_suppress_kept_type() {
+        let language: Language = tree_sitter_javascript::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+
+        // Intentionally capture the same call site as Type first, then Call.
+        // With cap=1, the Type ref is kept and the Call ref is dropped.
+        // Dropped refs must not influence dedup suppression.
+        let query = Query::new(
+            &language,
+            "(call_expression function: (identifier) @name) @reference.type
+             (call_expression function: (identifier) @name) @reference.call",
+        )
+        .unwrap();
+
+        let hooks = crate::symbols::hooks::javascript::hooks();
+        let (_symbols, refs) = extract(
+            &mut parser,
+            &query,
+            "foo();",
+            Arc::from("cap.js"),
+            &hooks,
+            false,
+            1,
+        );
+
+        assert_eq!(refs.len(), 1, "one ref should remain under cap=1");
+        assert_eq!(refs[0].name, "foo");
+        assert_eq!(refs[0].line, 1);
+        assert_eq!(refs[0].kind, ReferenceKind::Type);
+    }
 }

--- a/src/symbols/tests.rs
+++ b/src/symbols/tests.rs
@@ -82,23 +82,21 @@ def save(path: str, data: dict):
         f.write(json.dumps(data))
 "#;
     let (_syms, refs) = extract_file("py", source, Arc::from("io.py"), false, 0);
-    let call_refs: Vec<&ReferenceInfo> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    let names: Vec<&str> = call_refs.iter().map(|r| r.name.as_str()).collect();
-    assert!(names.contains(&"loads"), "got {:?}", names);
-    assert!(names.contains(&"dumps"));
-    assert!(names.contains(&"read"));
-
-    // open() is in the stoplist (builtin), should not appear
-    assert!(
-        !names.contains(&"open"),
-        "open() is builtin, should be in stoplist"
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("dumps".into(), 9, Some("save".into())),
+            ("loads".into(), 5, Some("load".into())),
+            ("read".into(), 4, Some("load".into())),
+            ("write".into(), 9, Some("save".into())),
+        ]
     );
-
-    let loads_ref = call_refs.iter().find(|r| r.name == "loads").unwrap();
-    assert_eq!(loads_ref.enclosing_symbol.as_deref(), Some("load"));
 }
 
 #[test]
@@ -120,6 +118,24 @@ from os.path import join
 }
 
 #[test]
+fn test_python_type_references() {
+    let source = r#"class Config:
+    pass
+
+def build(req: Request) -> Config:
+    return Config()
+"#;
+    let (_syms, refs) = extract_file("py", source, Arc::from("types.py"), false, 0);
+    let mut type_refs: Vec<(String, usize)> = refs
+        .iter()
+        .filter(|r| r.kind == ReferenceKind::Type)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    type_refs.sort();
+    assert_eq!(type_refs, vec![("Config".into(), 4), ("Request".into(), 4)]);
+}
+
+#[test]
 fn test_python_impl_references() {
     let source = r#"class Base:
     pass
@@ -138,6 +154,23 @@ class Multi(Base, Mixin):
         .collect();
     assert!(names.contains(&"Base"), "got {:?}", names);
     assert!(names.contains(&"Mixin"));
+}
+
+#[test]
+fn test_python_lambda_call_uses_outer_function_as_enclosing() {
+    let source = r#"def transform(items):
+    return list(map(lambda x: normalize(x), items))
+"#;
+    let (_syms, refs) = extract_file("py", source, Arc::from("lambda.py"), false, 0);
+    let normalize_call = refs
+        .iter()
+        .find(|r| r.kind == ReferenceKind::Call && r.name == "normalize")
+        .unwrap();
+    assert_eq!(normalize_call.line, 2);
+    assert_eq!(
+        normalize_call.enclosing_symbol.as_deref(),
+        Some("transform")
+    );
 }
 
 // ============================================================
@@ -238,24 +271,20 @@ func validate(c Config) error { return nil }
 "#;
     let (_syms, refs) = extract_file("go", source, Arc::from("main.go"), false, 0);
 
-    let call_refs: Vec<&ReferenceInfo> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    let names: Vec<&str> = call_refs.iter().map(|r| r.name.as_str()).collect();
-    assert!(
-        names.contains(&"parseConfig"),
-        "expected call-ref to parseConfig, got {:?}",
-        names
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("Println".into(), 7, Some("handleRequest".into())),
+            ("parseConfig".into(), 6, Some("handleRequest".into())),
+            ("validate".into(), 8, Some("handleRequest".into())),
+        ]
     );
-    assert!(
-        names.contains(&"validate"),
-        "expected call-ref to validate, got {:?}",
-        names
-    );
-
-    let parse_ref = call_refs.iter().find(|r| r.name == "parseConfig").unwrap();
-    assert_eq!(parse_ref.enclosing_symbol.as_deref(), Some("handleRequest"));
 }
 
 #[test]
@@ -529,13 +558,19 @@ function buildResponse(cfg: Config): Response {
 }
 "#;
     let (_syms, refs) = extract_file("ts", source, Arc::from("handler.ts"), false, 0);
-    let call_names: Vec<&str> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
-        .map(|r| r.name.as_str())
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    assert!(call_names.contains(&"parseConfig"), "got {:?}", call_names);
-    assert!(call_names.contains(&"buildResponse"));
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("buildResponse".into(), 5, Some("handle".into())),
+            ("parseConfig".into(), 4, Some("handle".into())),
+        ]
+    );
 }
 
 #[test]
@@ -642,6 +677,23 @@ import { handler } from './handler';
 }
 
 #[test]
+fn test_typescript_arrow_call_references_use_anonymous_enclosing() {
+    let source = r#"class Handler {
+  run() {
+    const f = () => parseConfig();
+  }
+}
+"#;
+    let (_syms, refs) = extract_file("ts", source, Arc::from("arrow.ts"), false, 0);
+    let parse = refs
+        .iter()
+        .find(|r| r.kind == ReferenceKind::Call && r.name == "parseConfig")
+        .unwrap();
+    assert_eq!(parse.line, 3);
+    assert_eq!(parse.enclosing_symbol.as_deref(), Some("<anonymous>"));
+}
+
+#[test]
 fn test_javascript_call_references() {
     let source = r#"import { parseConfig } from './config.js';
 
@@ -655,13 +707,19 @@ function buildResponse(cfg) {
 }
 "#;
     let (_syms, refs) = extract_file("js", source, Arc::from("h.js"), false, 0);
-    let names: Vec<&str> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
-        .map(|r| r.name.as_str())
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    assert!(names.contains(&"parseConfig"), "got {:?}", names);
-    assert!(names.contains(&"buildResponse"), "got {:?}", names);
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("buildResponse".into(), 5, Some("handle".into())),
+            ("parseConfig".into(), 4, Some("handle".into())),
+        ]
+    );
 }
 
 #[test]
@@ -677,6 +735,40 @@ class Derived extends Base {}
         .map(|r| r.name.as_str())
         .collect();
     assert!(impl_names.contains(&"Base"), "got {:?}", impl_names);
+}
+
+#[test]
+fn test_javascript_import_references() {
+    let source = r#"import { parseConfig, buildResponse } from './config.js';
+"#;
+    let (_syms, refs) = extract_file("js", source, Arc::from("imports.js"), false, 0);
+    let mut import_refs: Vec<(String, usize)> = refs
+        .iter()
+        .filter(|r| r.kind == ReferenceKind::Import)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    import_refs.sort();
+    assert_eq!(
+        import_refs,
+        vec![("buildResponse".into(), 1), ("parseConfig".into(), 1)]
+    );
+}
+
+#[test]
+fn test_javascript_arrow_call_references_use_anonymous_enclosing() {
+    let source = r#"class Handler {
+  run() {
+    const f = () => parseConfig();
+  }
+}
+"#;
+    let (_syms, refs) = extract_file("js", source, Arc::from("arrow.js"), false, 0);
+    let parse = refs
+        .iter()
+        .find(|r| r.kind == ReferenceKind::Call && r.name == "parseConfig")
+        .unwrap();
+    assert_eq!(parse.line, 3);
+    assert_eq!(parse.enclosing_symbol.as_deref(), Some("<anonymous>"));
 }
 
 // ============================================================
@@ -868,20 +960,37 @@ public class UserService {
 }
 "#;
     let (_syms, refs) = extract_file("java", source, Arc::from("UserService.java"), false, 0);
-    let call_names: Vec<&str> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
-        .map(|r| r.name.as_str())
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    assert!(call_names.contains(&"lookup"), "got {:?}", call_names);
-    assert!(call_names.contains(&"validate"), "got {:?}", call_names);
-    assert!(call_names.contains(&"insert"), "got {:?}", call_names);
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("insert".into(), 14, Some("saveUser".into())),
+            ("lookup".into(), 9, Some("fetchUser".into())),
+            ("validate".into(), 13, Some("saveUser".into())),
+        ]
+    );
+}
 
-    let lookup_ref = refs
+#[test]
+fn test_java_type_references() {
+    let source = r#"class Repo {}
+class Service {
+  Repo load(Repo r) { return r; }
+}
+"#;
+    let (_syms, refs) = extract_file("java", source, Arc::from("types.java"), false, 0);
+    let mut type_refs: Vec<(String, usize)> = refs
         .iter()
-        .find(|r| r.name == "lookup" && r.kind == ReferenceKind::Call)
-        .unwrap();
-    assert_eq!(lookup_ref.enclosing_symbol.as_deref(), Some("fetchUser"));
+        .filter(|r| r.kind == ReferenceKind::Type)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    type_refs.sort();
+    assert_eq!(type_refs, vec![("Repo".into(), 3), ("Repo".into(), 3)]);
 }
 
 #[test]
@@ -919,6 +1028,26 @@ import java.util.Map;
     // simple name from `java.util.List`, not the full qualified path.
     assert!(imp_names.contains(&"List"), "got {:?}", imp_names);
     assert!(imp_names.contains(&"Map"), "got {:?}", imp_names);
+}
+
+#[test]
+fn test_java_inner_class_call_enclosing_uses_inner_method() {
+    let source = r#"class Outer {
+  void outer() {
+    class Inner {
+      void run() { helper(); }
+      void helper() {}
+    }
+  }
+}
+"#;
+    let (_syms, refs) = extract_file("java", source, Arc::from("inner.java"), false, 0);
+    let helper_call = refs
+        .iter()
+        .find(|r| r.kind == ReferenceKind::Call && r.name == "helper")
+        .unwrap();
+    assert_eq!(helper_call.line, 4);
+    assert_eq!(helper_call.enclosing_symbol.as_deref(), Some("run"));
 }
 
 // ============================================================
@@ -1791,13 +1920,53 @@ object Service {
 }
 "#;
     let (_syms, refs) = extract_file("scala", source, Arc::from("svc.scala"), false, 0);
-    let names: Vec<&str> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
-        .map(|r| r.name.as_str())
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    assert!(names.contains(&"parseConfig"), "got {:?}", names);
-    assert!(names.contains(&"buildResponse"));
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("Config".into(), 9, Some("parseConfig".into())),
+            ("Response".into(), 10, Some("buildResponse".into())),
+            ("buildResponse".into(), 6, Some("process".into())),
+            ("parseConfig".into(), 5, Some("process".into())),
+        ]
+    );
+}
+
+#[test]
+fn test_scala_type_references() {
+    let source = r#"class Config
+object Service {
+  def load(c: Config): Config = c
+}
+"#;
+    let (_syms, refs) = extract_file("scala", source, Arc::from("types.scala"), false, 0);
+    let mut type_refs: Vec<(String, usize)> = refs
+        .iter()
+        .filter(|r| r.kind == ReferenceKind::Type)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    type_refs.sort();
+    assert_eq!(type_refs, vec![("Config".into(), 3), ("Config".into(), 3)]);
+}
+
+#[test]
+fn test_scala_import_references() {
+    let source = r#"import Config
+
+object Service
+"#;
+    let (_syms, refs) = extract_file("scala", source, Arc::from("imports.scala"), false, 0);
+    let import_refs: Vec<(String, usize)> = refs
+        .iter()
+        .filter(|r| r.kind == ReferenceKind::Import)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    assert_eq!(import_refs, vec![("Config".into(), 1)]);
 }
 
 #[test]
@@ -2681,21 +2850,38 @@ class Loader
 end
 "#;
     let (_syms, refs) = extract_file("rb", source, Arc::from("loader.rb"), false, 0);
-    let names: Vec<&str> = refs
+    let mut call_refs: Vec<(String, usize, Option<String>)> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Call)
-        .map(|r| r.name.as_str())
+        .map(|r| (r.name.clone(), r.line, r.enclosing_symbol.clone()))
         .collect();
-    assert!(names.contains(&"read"), "got {:?}", names);
-    assert!(names.contains(&"parse"));
-    assert!(names.contains(&"write"));
-    assert!(names.contains(&"dump"));
+    call_refs.sort();
+    assert_eq!(
+        call_refs,
+        vec![
+            ("dump".into(), 10, Some("save".into())),
+            ("parse".into(), 6, Some("load".into())),
+            ("read".into(), 5, Some("load".into())),
+            ("write".into(), 10, Some("save".into())),
+        ]
+    );
+}
 
-    let parse_ref = refs
+#[test]
+fn test_ruby_type_references() {
+    let source = r#"class Loader
+  def load(raw)
+    JSON.parse(raw)
+  end
+end
+"#;
+    let (_syms, refs) = extract_file("rb", source, Arc::from("types.rb"), false, 0);
+    let type_refs: Vec<(String, usize)> = refs
         .iter()
-        .find(|r| r.name == "parse" && r.kind == ReferenceKind::Call)
-        .unwrap();
-    assert_eq!(parse_ref.enclosing_symbol.as_deref(), Some("load"));
+        .filter(|r| r.kind == ReferenceKind::Type)
+        .map(|r| (r.name.clone(), r.line))
+        .collect();
+    assert_eq!(type_refs, vec![("JSON".into(), 3)]);
 }
 
 #[test]
@@ -2728,17 +2914,59 @@ fn test_ruby_require_references() {
 require_relative './util'
 "#;
     let (_syms, refs) = extract_file("rb", source, Arc::from("m.rb"), false, 0);
-    let imp_names: Vec<&str> = refs
+    let mut imp_names: Vec<String> = refs
         .iter()
         .filter(|r| r.kind == ReferenceKind::Import)
-        .map(|r| r.name.as_str())
+        .map(|r| r.name.clone())
         .collect();
-    assert!(
-        imp_names.iter().any(|n| n.contains("json")),
-        "got {:?}",
-        imp_names
+    imp_names.sort();
+    assert_eq!(imp_names, vec!["./util".to_string(), "json".to_string()]);
+}
+
+#[test]
+fn test_ruby_block_call_uses_outer_method_as_enclosing() {
+    let source = r#"class Job
+  def run(items)
+    items.each do |item|
+      process(item)
+    end
+  end
+end
+"#;
+    let (_syms, refs) = extract_file("rb", source, Arc::from("job.rb"), false, 0);
+    let process_call = refs
+        .iter()
+        .find(|r| r.kind == ReferenceKind::Call && r.name == "process")
+        .unwrap();
+    assert_eq!(process_call.line, 4);
+    assert_eq!(process_call.enclosing_symbol.as_deref(), Some("run"));
+}
+
+#[test]
+fn test_ruby_type_call_dedup_for_constant_call() {
+    let source = r#"def load(raw)
+  JSON(raw)
+end
+"#;
+    let (_syms, refs) = extract_file("rb", source, Arc::from("dedup.rb"), false, 0);
+    let json_calls: Vec<&ReferenceInfo> = refs
+        .iter()
+        .filter(|r| r.name == "JSON" && r.kind == ReferenceKind::Call)
+        .collect();
+    let json_types: Vec<&ReferenceInfo> = refs
+        .iter()
+        .filter(|r| r.name == "JSON" && r.kind == ReferenceKind::Type)
+        .collect();
+    assert_eq!(json_calls.len(), 1, "JSON(raw) should emit one call-ref");
+    assert_eq!(
+        json_calls[0].enclosing_symbol.as_deref(),
+        Some("load"),
+        "JSON call should be attributed to load"
     );
-    assert!(imp_names.iter().any(|n| n.contains("util")));
+    assert!(
+        json_types.is_empty(),
+        "type-ref at the same node/line must be deduplicated against call-ref"
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2364,7 +2364,7 @@ fn test_references_incremental_rebuild() {
     fs::write(root.join("svc/go.mod"), "module svc\n\ngo 1.22\n").unwrap();
     fs::write(
         root.join("svc/a.go"),
-        "package svc\n\nfunc A() { B() }\nfunc B() {}\n",
+        "package svc\n\nfunc A(){ B() }\nfunc B() {}\n",
     )
     .unwrap();
 
@@ -2426,6 +2426,169 @@ fn test_references_incremental_rebuild() {
     assert_eq!(
         count_b_after, 0,
         "call-ref to B should be removed after file modification"
+    );
+}
+
+fn run_build_for_root(bin: &Path, root: &Path) {
+    let output = Command::new(bin)
+        .args(["build", "--root", root.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn count_b_call_refs(root: &Path, path: Option<&str>, package: Option<&str>) -> i64 {
+    let conn = rusqlite::Connection::open(root.join(".shire/index.db")).unwrap();
+    match (path, package) {
+        (Some(path), Some(package)) => conn
+            .query_row(
+                "SELECT COUNT(*) \
+                 FROM symbol_refs r \
+                 JOIN files f ON f.id = r.file_id \
+                 WHERE r.name = 'B' AND r.kind = 'call' \
+                   AND f.path = ?1 AND r.package = ?2",
+                [path, package],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        (Some(path), None) => conn
+            .query_row(
+                "SELECT COUNT(*) \
+                 FROM symbol_refs r \
+                 JOIN files f ON f.id = r.file_id \
+                 WHERE r.name = 'B' AND r.kind = 'call' AND f.path = ?1",
+                [path],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        (None, Some(package)) => conn
+            .query_row(
+                "SELECT COUNT(*) \
+                 FROM symbol_refs \
+                 WHERE name = 'B' AND kind = 'call' AND package = ?1",
+                [package],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        (None, None) => conn
+            .query_row(
+                "SELECT COUNT(*) FROM symbol_refs WHERE name = 'B' AND kind = 'call'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap(),
+    }
+}
+
+#[test]
+fn test_references_incremental_rebuild_deleted_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let bin = cargo_bin();
+
+    fs::write(
+        root.join("shire.toml"),
+        "db_path = \".shire/index.db\"\n\n[symbols]\nreferences_enabled = true\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("svc")).unwrap();
+    fs::write(root.join("svc/go.mod"), "module svc\n\ngo 1.22\n").unwrap();
+    fs::write(
+        root.join("svc/a.go"),
+        "package svc\n\nfunc A() { B() }\nfunc B() {}\n",
+    )
+    .unwrap();
+
+    run_build_for_root(&bin, root);
+    assert_eq!(count_b_call_refs(root, Some("svc/a.go"), Some("svc")), 1);
+
+    fs::remove_file(root.join("svc/a.go")).unwrap();
+    run_build_for_root(&bin, root);
+    assert_eq!(
+        count_b_call_refs(root, None, None),
+        0,
+        "call-ref should disappear when the source file is deleted"
+    );
+}
+
+#[test]
+fn test_references_incremental_rebuild_renamed_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let bin = cargo_bin();
+
+    fs::write(
+        root.join("shire.toml"),
+        "db_path = \".shire/index.db\"\n\n[symbols]\nreferences_enabled = true\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("svc")).unwrap();
+    fs::write(root.join("svc/go.mod"), "module svc\n\ngo 1.22\n").unwrap();
+    fs::write(
+        root.join("svc/a.go"),
+        "package svc\n\nfunc A() { B() }\nfunc B() {}\n",
+    )
+    .unwrap();
+
+    run_build_for_root(&bin, root);
+    assert_eq!(count_b_call_refs(root, Some("svc/a.go"), Some("svc")), 1);
+
+    fs::rename(root.join("svc/a.go"), root.join("svc/renamed.go")).unwrap();
+    // Ensure the moved path is observed as changed by mtime pre-check logic.
+    fs::write(
+        root.join("svc/renamed.go"),
+        "package svc\n\nfunc A() { B() }\nfunc B() {}\n",
+    )
+    .unwrap();
+    run_build_for_root(&bin, root);
+    assert_eq!(count_b_call_refs(root, Some("svc/a.go"), None), 0);
+    assert_eq!(count_b_call_refs(root, Some("svc/renamed.go"), None), 1);
+}
+
+#[test]
+fn test_references_incremental_rebuild_file_moves_between_packages() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let bin = cargo_bin();
+
+    fs::write(
+        root.join("shire.toml"),
+        "db_path = \".shire/index.db\"\n\n[symbols]\nreferences_enabled = true\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("svc")).unwrap();
+    fs::create_dir_all(root.join("other")).unwrap();
+    fs::write(root.join("svc/go.mod"), "module svc\n\ngo 1.22\n").unwrap();
+    fs::write(root.join("other/go.mod"), "module other\n\ngo 1.22\n").unwrap();
+    fs::write(
+        root.join("svc/a.go"),
+        "package svc\n\nfunc A() { B() }\nfunc B() {}\n",
+    )
+    .unwrap();
+
+    run_build_for_root(&bin, root);
+    assert_eq!(count_b_call_refs(root, Some("svc/a.go"), Some("svc")), 1);
+
+    fs::rename(root.join("svc/a.go"), root.join("other/renamed.go")).unwrap();
+    fs::write(
+        root.join("other/renamed.go"),
+        "package other\n\nfunc A() { B() }\nfunc B() {}\n",
+    )
+    .unwrap();
+    run_build_for_root(&bin, root);
+    assert_eq!(count_b_call_refs(root, Some("svc/a.go"), None), 0);
+    assert_eq!(
+        count_b_call_refs(root, Some("other/renamed.go"), Some("other")),
+        1
+    );
+    assert_eq!(
+        count_b_call_refs(root, None, Some("svc")),
+        0,
+        "moved refs should no longer be attributed to the old package"
     );
 }
 


### PR DESCRIPTION
## Summary
- fill D4/D10/D12/D13 coverage gaps in db ref-query tests
- add D5 incremental rebuild cases for delete, rename, and cross-package moves
- fill missing language/kind matrix coverage and strengthen deterministic ref assertions
- add enclosing-symbol nesting tests and Ruby type/call dedup regression coverage
- add small extractor fixes for anonymous enclosing symbols and type-vs-call dedup by name+line

## Testing
- cargo test refs_tests:: --lib
- cargo test symbols::tests:: --lib
- cargo test --test integration references_incremental_rebuild_ -- --nocapture

Refs #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Type reference deduplication improved so call/type at the same location don’t erroneously suppress one another.
  * Anonymous functions are now attributed as enclosing symbols where appropriate.
  * Caller grouping/counts remain correct when sparse/null groups exist, preserving expected caller rows.

* **Improvements**
  * Incremental builds better handle deleted, renamed, and moved files so cross-file references update reliably.
  * Symbol queries treat visually equivalent Unicode names distinctly (NFC/NFD).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->